### PR TITLE
Beta-decode each lemma and headword only once.

### DIFF
--- a/transform_lemmata.py
+++ b/transform_lemmata.py
@@ -46,11 +46,15 @@ def parse_perseus_lemmata_file(file_generator, greek):
             print('Parsing line {0}'.format(count))
         line_split = line.split('\t')
         headword = line_split[0]
+        if greek:
+            headword = replacer.beta_code(headword.upper() + ' ')[:-1].lower()  # add space to get final sigma 'ς', then rm it
         headword_id = line_split[1]
         line_lemmata = line_split[2:]
         for lemma_str in line_lemmata:
             lemma_list = lemma_str.split(' ', 1)
             lemma = lemma_list[0]
+            if greek:
+                lemma = replacer.beta_code(lemma.upper() + ' ')[:-1].lower()  # add space to get final sigma 'ς', then rm it #? why some coming out capitalized?
             lemma_pos_str = lemma_list[1]
             lemma_pos_list = lemma_pos_str.split(') (')
 
@@ -69,10 +73,6 @@ def parse_perseus_lemmata_file(file_generator, greek):
                     lemma_pos = lemma_pos_list[0]
                     lemma_pos_comment = lemma_pos_list[1][:-1]
                     lemma_pos_comment_list = lemma_pos_comment.split(' ')
-
-                if greek:
-                    lemma = replacer.beta_code(lemma.upper() + ' ')[:-1].lower()  # add space to get final sigma 'ς', then rm it #? why some coming out capitalized?
-                    headword = replacer.beta_code(headword.upper() + ' ')[:-1].lower()  # add space to get final sigma 'ς', then rm it
 
                 #print(lemma, headword)
 


### PR DESCRIPTION
This patch changes `parse_perseus_lemmata_file` to call `replacer.beta_code` only once on each `headword` and `lemma`.

Before this change, the output `LEMMATA` had 949453 entries. After this change, it has 892000, a reduction of about 6%. It's worth noting that some users may be relying on `LEMMATA` containing redundant entries that differ only in normalization, but in any case it would not be safe to rely on that, because it depended on factors such as a lemma having multiple parts of speech.

This change happens to make the code faster, as it makes fewer calls to `replacer.beta_code`, which is the slowest part of the loop.

Fixes #5.

Incidentally, the terms `headword` and `lemma` seem to be swapped in the code; the output dictionary has headwords for keys and lemmata for values, but the variable names are the opposite of that. The inner `for lemma_pos in lemma_pos_list` loop seems to be superfluous, only yielding duplicate values that will be discarded by the caller, but I left it alone.